### PR TITLE
Rename `RouterTrait` -> `RouteHandler`

### DIFF
--- a/restly/src/app.rs
+++ b/restly/src/app.rs
@@ -4,7 +4,7 @@ use tokio::net::{TcpListener, TcpStream};
 
 use crate::requrest::Req;
 use crate::route::Route;
-use crate::router::RouterTrait;
+use crate::router::RouteHandler;
 
 pub struct App<'a> {
     routes: Vec<Route<'a>>,
@@ -65,7 +65,7 @@ impl<'a> App<'a> {
     }
 }
 
-impl RouterTrait for App<'_> {
+impl RouteHandler for App<'_> {
     fn get<F>(path: &str, handler: F)
     where
         F: Fn(),

--- a/restly/src/router.rs
+++ b/restly/src/router.rs
@@ -1,5 +1,4 @@
-// TODO: Rename in more blasingly fast manner
-pub trait RouterTrait {
+pub trait RouteHandler {
     fn get<F>(path: &str, handler: F) where F: Fn();
     fn post<F>(path: &str, handler: F) where F: Fn();
     fn put<F>(path: &str, handler: F) where F: Fn();


### PR DESCRIPTION
Probable not the best name but any way better than `RouterTrait`